### PR TITLE
Improved the speed of skipping past existing files

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -84,7 +84,6 @@ def upload(path, parent_id, overwr, force):
 
 
 def upload_file(path, parent_id, overwr, force):
-    hasher = utils.Hasher(path)
     short_nm = os.path.basename(path)
 
     cached_file = query.get_node(parent_id).get_child(short_nm)
@@ -95,6 +94,7 @@ def upload_file(path, parent_id, overwr, force):
 
     if not file_id:
         try:
+            hasher = utils.Hasher(path)
             r = content.upload_file(path, parent_id)
             sync.insert_node(r)
             file_id = r['id']
@@ -122,19 +122,19 @@ def upload_file(path, parent_id, overwr, force):
 
         if not overwr and not force:
             print('Skipping upload of existing file "%s".' % short_nm)
-            hasher.stop()
             return 0
 
         # ctime is checked because files can be overwritten by files with older mtime
         if mod_time < os.path.getmtime(path) \
                 or (mod_time < os.path.getctime(path) and cached_file.size != os.path.getsize(path)) \
                 or force:
-            hasher.stop()
             return overwrite(file_id, path)
         elif not force:
             print('Skipping upload of "%s" because of mtime or ctime and size.' % short_nm)
-            hasher.stop()
             return 0
+        else:
+            hasher = utils.Hasher(path)
+
 
     # might have changed
     cached_file = query.get_node(file_id)


### PR DESCRIPTION
...  when uploading by only hashing the file when needed.

Hi there, let me just say this is a great initiative and I'm really looking forward to the planned "smart sync" feature.

In the meantime, trying to upload a nearly 1 TB collection of photos. I have to repeatedly stop the process to disconnect my computer from the drive and then resume later. And I wondered why it took so long to simply skip the file if it already existed. So I took a peek at the `upload_file` function to see if I could improve it.
And it looks like the hashing isn't needed to detect if the file should be skipped. So I moved the hashing around a bit to try and improve it. This seems to work on my local and it indeed skips past existing files at an incredible rate now - I might have missed something, so please take a look at let me know what you think. If it makes sense you can commit it to your master branch and include it with the next version.

Cheers,
Stefan