### PR TITLE
adding search for files by md5 hash value

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -439,6 +439,11 @@ def find_action(args):
         print(node)
 
 
+def find_md5_action(args):
+    node = query.find_md5(args.md5)
+    print(node)
+
+
 def children_action(args):
     c_list = query.list_children(args.node, args.recursive, args.include_trash)
     if c_list:
@@ -603,6 +608,11 @@ def main():
                                     help='find nodes by name [offline operation] [case insensitive]')
     find_sp.add_argument('name')
     find_sp.set_defaults(func=find_action)
+
+    findhash_nms = ['find-md5', 'fh']
+    findhash_sp = subparsers.add_parser(findhash_nms[0], aliases=findhash_nms[1:], help='find files by md5 hash [offline operation]')
+    findhash_sp.add_argument('md5')
+    findhash_sp.set_defaults(func=find_md5_action)
 
     # maybe the child operations should not be exposed
     # they can be used for creating hardlinks

--- a/cache/query.py
+++ b/cache/query.py
@@ -112,6 +112,18 @@ def find(name) -> list:
     return nodes
 
 
+def find_md5(md5) -> list:
+    # allow us to find potential duplicates easily
+    q = db.session.query(db.File).filter_by(md5=md5) #.first()
+    q = sorted(q, key=lambda x: x.full_path())
+
+    nodes = []
+    for node in q:
+        nodes.append(node.long_id_str())
+        print(node.md5)
+    return nodes
+
+
 def resolve_path(path, root=None, trash=True) -> db.Node:
     """Resolves absolute path to node id if fully unique"""
     if not path or (not root and '/' not in path):

--- a/cache/query.py
+++ b/cache/query.py
@@ -120,7 +120,6 @@ def find_md5(md5) -> list:
     nodes = []
     for node in q:
         nodes.append(node.long_id_str())
-        print(node.md5)
     return nodes
 
 


### PR DESCRIPTION
Searching with md5 hash values in invaluable. You can easily find duplicates on your ACD and check if a local file already exists on ACD under a different file name. #24 