### PR TITLE
acd_cli.py deduplicate fix

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -261,9 +261,9 @@ def upload_file(path: str, parent_id: str, overwr: bool, force: bool, dedup: boo
     if dedup and query.file_size_exists(os.path.getsize(path)):
         nodes = query.find_md5(hashing.hash_file(path))
         nodes = [n for n in format.PathFormatter(nodes)]
-        if len(nodes) > 0:
+        for node in nodes:
             # print('Skipping upload of duplicate file "%s".' % short_nm)
-            logger.info('Location of duplicates: %s' % nodes)
+            logger.info('Location of duplicates: %s' % node)
             pg_handler.done()
             return DUPLICATE
 


### PR DESCRIPTION
```
deduplicate error:
15-06-12 21:31:39.128 [ERROR] [acd_cli] - Traceback (most recent call last):
  File "/home/user/.local/bin/acd_cli.py", line 166, in wrapped
    ret_val = f(*args, **kwargs)
  File "/home/user/.local/bin/acd_cli.py", line 272, in upload_file
    if len(nodes) > 0:
TypeError: object of type 'generator' has no len()
```