### PR TITLE
New apps require read_all, read is deprecated

### DIFF
--- a/acdcli/api/oauth.py
+++ b/acdcli/api/oauth.py
@@ -203,7 +203,7 @@ class LocalOAuthHandler(OAuthHandler):
 
         self.OAUTH_ST1 = lambda: {'client_id': self.client_id(),
                                   'response_type': 'code',
-                                  'scope': 'clouddrive:read clouddrive:write',
+                                  'scope': 'clouddrive:read_all clouddrive:write',
                                   'redirect_uri': self.REDIRECT_URI}
 
         self.OAUTH_ST2 = lambda: {'grant_type': 'authorization_code',


### PR DESCRIPTION
https://developer.amazon.com/public/apis/experience/cloud-drive/content/getting-started

If someone tries to use their own API credentials at the moment, they will trip on a 400 error. I determined the issue to be an invalid scope and this is because the scope key has changed.

If the Google app engine python application still uses `read`, this should also be updated.