### PR TITLE
assets: Add systemd user service file for init

### DIFF
--- a/assets/amazon-cloud-drive.service
+++ b/assets/amazon-cloud-drive.service
@@ -1,0 +1,18 @@
+# $HOME/.config/systemd/user/amazon-cloud-drive.service
+#
+# Usage:
+# * Setup acd_cli normally and create $HOME/Cloud
+# * Copy file to:   $HOME/.config/systemd/user/amazon-cloud-drive.serivce
+# * Reload systemd: systemctl --user daemon-reload
+# * Start service:  systemctl --user start amazon-cloud-drive.serivce
+[Unit]
+Description=User Amazon Cloud Drive FUSE Mount
+Documentation=https://github.com/yadayada/acd_cli
+
+[Service]
+AssertPathIsDirectory=%h/Cloud
+ExecStart=/usr/bin/acd_cli -v mount --foreground %h/Cloud
+Restart=on-abort
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
* This will cause cloud drive to be mounted everytime the user logins
  after the user enables it with:
  `systemctl --user enable amazon-cloud-drive.service`
* Serves as a template for package maintainers to install into
  `/lib/systemd/user/`
* The verbose flag is passed so that journalctl logs data