### PR TITLE
added missing arguments for directory upload

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/home/brian/aws/py34/bin/python3
 import sys
 import os
 import json
@@ -260,7 +260,7 @@ def create_upload_jobs(dirs: list, path: str, parent_id: str, overwr: bool, forc
             return DUPLICATE_DIR
         dirs.append(ino)
         return traverse_ul_dir(dirs, path, parent_id, overwr, force, dedup,
-                               exclude, exclude_paths, jobs)
+                               rsf, exclude, exclude_paths, jobs)
     elif os.path.isfile(path):
         short_nm = os.path.basename(path)
         for reg in exclude:
@@ -377,7 +377,7 @@ def upload_file(path: str, parent_id: str, overwr: bool, force: bool, dedup: boo
             cache.insert_node(r)
             node = cache.get_node(r['id'])
 
-            match = compare_hashes(hasher.get_result(), node.md5)
+            match = compare_hashes(hasher.get_result(), node.md5, path)
             if match != 0:
                 return match
 

--- a/acd_cli.py
+++ b/acd_cli.py
@@ -1,4 +1,4 @@
-#!/home/brian/aws/py34/bin/python3
+#!/usr/bin/env python3
 import sys
 import os
 import json


### PR DESCRIPTION
I attempted the following:
python acd_cli.py --verbose upload /path/to/local/folder/ /existing/remote/folder/

Initially the upload failed due to a missing parameter to traverse_ul_dir on line 263.  After adding the missing rsf parameter, the upload succeeded, but I received warning in the verbose output about the filename being omitted from the call to compare_hashes on line 380.  After passing the path along to the compare_hashes call, the command succeeded.

For reference, I was using Python 3.4.3 on Ubuntu Server 14.04.