### PR TITLE
Added Parameter to Remove Extraneous Files on Upload

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -20,7 +20,7 @@ from pkg_resources import iter_entry_points
 import acdcli
 from acdcli.api import client
 from acdcli.api.common import RequestError, is_valid_id
-from acdcli.cache import db, format
+from acdcli.cache import db, format, schema
 from acdcli.utils import hashing, progress
 from acdcli.utils.threading import QueuedLoader
 
@@ -658,6 +658,31 @@ def regex_helper(args: argparse.Namespace) -> 'List[re._pattern_type]':
     return excl_re
 
 
+def delete_extraneous(node, path, exclude_re, exclude_paths, delete_excluded):
+    if node == None or node.status == 'TRASH':
+        return
+
+    if not os.path.exists(path):
+        name = os.path.basename(path)
+
+        #determine whether the missing file matches any exclude pattern
+        path_excluded = (path in exclude_paths) or any(map(lambda x: re.match(x, name), exclude_re))
+
+        if delete_excluded or not path_excluded:
+            logger.info('Moving "%s" to trash as it has been removed locally.' % node.name)
+
+            r = acd_client.move_to_trash(node.id)
+            cache.insert_node(r)
+
+            return
+
+    if isinstance(node, schema.Folder):
+        for child in node.children:
+            child_path = os.path.join(path, child.name)
+
+            delete_extraneous(child, child_path, exclude_re, exclude_paths, delete_excluded)
+
+
 @no_autores_trash_action
 def upload_action(args: argparse.Namespace) -> int:
     if not cache.get_node(args.parent):
@@ -665,6 +690,15 @@ def upload_action(args: argparse.Namespace) -> int:
         return INVALID_ARG_RETVAL
 
     excl_re = regex_helper(args)
+
+    if args.delete:
+        exclude_paths = [os.path.realpath(p) for p in args.exclude_path]
+
+        for path in (os.path.realpath(p) for p in args.path):
+            # get destination node on server
+            node = cache.resolve('/' + os.path.basename(path), cache.get_node(args.parent))[0]
+
+            delete_extraneous(node, path, excl_re, exclude_paths, args.delete_excluded)
 
     jobs = []
     ret_val = 0
@@ -1221,6 +1255,10 @@ def get_parser() -> tuple:
                            help='exclude duplicate files from upload')
     upload_sp.add_argument('--remove-source-files', '-rsf', action='store_true',
                            help='remove local files on successful upload')
+    upload_sp.add_argument('--delete', action='store_true',
+                           help='delete extraneous files from dest dirs')
+    upload_sp.add_argument('--delete-excluded', action='store_true',
+                           help='also delete excluded files from dest dirs')
     upload_sp.add_argument('path', nargs='+', help='a path to a local file or directory')
     upload_sp.add_argument('parent', help='remote parent folder')
     upload_sp.set_defaults(func=upload_action)

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -3,6 +3,8 @@ Contributors
 
 Thanks to
 
+- `sthm <https://github.com/sthm>`_ for extending the upload action
+
 - `chrisidefix <https://github.com/chrisidefix>`_ for adding the find-md5 action and 
   forcing me to create a proper package and use PyPI
 


### PR DESCRIPTION
This commit adds two parameters (--delete, --delete-excluded) to the upload
command. When specified, files that have been removed locally will be removed
(more precisely will be moved to the trash) on the server as well.

This functionality is usefull to keep local and remote conent in sync. It mimics
the behaviour of the respective rsync commands.