### PR TITLE
Fix --read-only option

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -1328,7 +1328,7 @@ def get_parser() -> tuple:
     meta_sp.set_defaults(func=metadata_action)
 
     fuse_sp = subparsers.add_parser('mount', help='[+] mount the cloud drive at a local directory')
-    fuse_sp.add_argument('--ro', '-ro', action='store_true', help='mount read-only')
+    fuse_sp.add_argument('--read-only', '-ro', action='store_true', help='mount read-only')
     fuse_sp.add_argument('--foreground', '-fg', action='store_true', help='do not detach')
     fuse_sp.add_argument('--single-threaded', '-st', action='store_true')
     # fuse_sp.add_argument('--multi-threaded', '-mt', action='store_false', dest='single_threaded')


### PR DESCRIPTION
According to the [docs](https://acd-cli.readthedocs.org/en/latest/FUSE.html#mount-options), there is a long-hand `--read-only` option. The code did not reflect this. This PR fixes that. 