### PR TITLE
use requests session to enable connection pooling

### DIFF
--- a/acdcli/acd_fuse.py
+++ b/acdcli/acd_fuse.py
@@ -139,6 +139,9 @@ class ReadProxy(object):
                 with self.lock:
                     chunk = ReadProxy.StreamChunk(acd_client, id_, offset,
                                                   CHUNK_SZ, timeout=CHUNK_TIMEOUT)
+                    if len(self.chunks) == MAX_CHUNKS_PER_FILE:
+                        self.chunks[0].close()
+
                     self.chunks.append(chunk)
                     return chunk.get(length)
             except RequestError as e:

--- a/acdcli/api/backoff_req.py
+++ b/acdcli/api/backoff_req.py
@@ -27,7 +27,7 @@ class BackOffRequest(object):
 
         self.auth_callback = auth_callback
 
-        # __session = None
+        self.__session = requests.session()
         self.__thr_local = local()
         self.__lock = Lock()
         self.__retries = 0
@@ -70,8 +70,6 @@ class BackOffRequest(object):
         :param acc_codes: list of HTTP status codes that indicate a successful request
         :param kwargs: may include additional header: dict and timeout: int"""
 
-        # if not self.__session:
-        #     self.__session = requests.session()
         self._wait()
 
         headers = {}
@@ -96,7 +94,7 @@ class BackOffRequest(object):
             timeout = REQUESTS_TIMEOUT
 
         try:
-            r = requests.request(type_, url, auth=self.auth_callback,
+            r = self.__session.request(type_, url, auth=self.auth_callback,
                                  headers=headers, timeout=timeout, **kwargs)
         except:
             self._failed()

--- a/acdcli/api/content.py
+++ b/acdcli/api/content.py
@@ -311,6 +311,7 @@ class ContentMixin(object):
             logger.debug('Range %d-%d' % (chunk_start, chunk_end))
             # this should only happen at the end of unknown-length downloads
             if r.status_code == http.REQUESTED_RANGE_NOT_SATISFIABLE:
+                r.close()
                 logger.debug('Invalid byte range requested %d-%d' % (chunk_start, chunk_end))
                 break
             if r.status_code not in ok_codes:


### PR DESCRIPTION
Hi,

I’m not sure why the session was commented out, please let me know if you ran into issues previously. According to the `requests` docs, streaming requests should be closed or read completely to return connections to the pool. I only found these two occurrences where a close was missing. Testing locally with many simultaneous requests, I did not see any problems running into limits.

Here is a very simple runtime comparison using the fuse mount:
```
time sh -c 'cd ~/acd/test && cat a && cat b && cat c'
# old:  2,658  2,604  2,998
# new:  2,230  2,148  2,307
```

Let's hope the tests pass on travis since they are failing for me even on master.
