### PR TITLE
tree: Add --dir-only and --max-depth options

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -635,7 +635,8 @@ def tree_action(args: argparse.Namespace):
         logger.critical('Invalid folder.')
         return INVALID_ARG_RETVAL
 
-    for line in cache.tree_format(node, args.node_path, args.include_trash):
+    for line in cache.tree_format(node, args.node_path, trash=args.include_trash,
+                                  dir_only=args.dir_only, max_depth=args.max_depth):
         print(line)
 
 
@@ -1175,6 +1176,8 @@ def get_parser() -> tuple:
     tree_sp = subparsers.add_parser('tree', aliases=['t'],
                                     help='[+] print directory tree [offline operation]')
     tree_sp.add_argument('--include-trash', '-t', action='store_true')
+    tree_sp.add_argument('--dir-only', '-d', action='store_true')
+    tree_sp.add_argument('--max-depth', '-L', type=int)
     tree_sp.add_argument('node', nargs='?', default='/', help='root folder for the tree')
     tree_sp.set_defaults(func=tree_action)
 

--- a/acdcli/cache/format.py
+++ b/acdcli/cache/format.py
@@ -136,20 +136,25 @@ class FormatterMixin(object):
                     yield n
 
 
-    def tree_format(self, node, path, trash=False, depth=0) -> 'Generator[str]':
+    def tree_format(self, node, path, trash=False, dir_only=False,
+                    depth=0, max_depth=None) -> 'Generator[str]':
         """A simple tree formatter that indicates parentship by indentation
         (i.e. does not display graphical branches like :program:`tree`)."""
 
         indent = ' ' * 4 * depth
         yield indent + color_path(node.simple_name)
+        if max_depth is not None and depth >= max_depth:
+            return
 
         indent += ' ' * 4
         folders, files = self.list_children(node.id, trash)
         for folder in folders:
-            for line in self.tree_format(folder, '', trash, depth + 1):
+            for line in self.tree_format(folder, '', trash, dir_only, depth + 1, max_depth):
                 yield line
-        for file in files:
-            yield indent + color_path(file.simple_name)
+
+        if not dir_only:
+            for file in files:
+                yield indent + color_path(file.simple_name)
 
     @staticmethod
     def id_format(nodes) -> 'Generator[str]':


### PR DESCRIPTION
The `-d` (directory only) and `-L level` (max depth) options of tree(1) are commonly used, and they fit easily into the current implementation, so why not.

Actually there are other commonly used options, e.g., `-s` (and by extension `-h`), but it is already kind of fulfilled by `acd_cli ls -r`.