### PR TITLE
bypass os.getuid and os.getgid on Windows

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -1390,9 +1390,12 @@ def get_parser() -> tuple:
                          help='allow access to other users')
     fuse_sp.add_argument('--umask', action='store', default=def_umask,
                          help='override the permission bits (umask) set by the filesystem (octet)')
-    fuse_sp.add_argument('--uid', action='store', default=os.getuid(),
+    if os.name == 'nt':
+        pass
+    else:
+        fuse_sp.add_argument('--uid', action='store', default=os.getuid(),
                          help='override the uid field set by the filesystem (numeric)')
-    fuse_sp.add_argument('--gid', action='store', default=os.getgid(),
+        fuse_sp.add_argument('--gid', action='store', default=os.getgid(),
                          help='override the gid field set by the filesystem (numeric)')
     fuse_sp.add_argument('--modules', action='store', default='',
                          help='add iconv or subdir modules')


### PR DESCRIPTION
Hi!
acd_cli failed to start on Windows due to os.getuid and os.getgid. I googled this workaround here: https://github.com/spotify/luigi/issues/578
Probably it would help.