### PR TITLE
support streaming empty files (fixes #128)

### DIFF
--- a/tests/test_api_live.py
+++ b/tests/test_api_live.py
@@ -104,6 +104,16 @@ class APILiveTestCase(unittest.TestCase):
 
         self.acd_client.move_to_trash(n['id'])
 
+    def test_upload_stream_empty(self):
+        empty_stream = io.BufferedReader(io.BytesIO())
+        fn = gen_rand_nm()
+
+        n = self.acd_client.upload_stream(empty_stream, fn, parent=None)
+        self.assertEqual(n['contentProperties']['md5'], 'd41d8cd98f00b204e9800998ecf8427e')
+        self.assertEqual(n['contentProperties']['size'], 0)
+
+        self.acd_client.move_to_trash(n['id'])
+
     def test_overwrite(self):
         f, sz = gen_temp_file()
         h = hashing.IncrementalHasher()
@@ -128,6 +138,11 @@ class APILiveTestCase(unittest.TestCase):
         n = self.acd_client.overwrite_stream(s, n['id'], [h.update])
         self.assertEqual(n['contentProperties']['md5'], h.get_result())
         self.assertEqual(n['contentProperties']['size'], sz)
+
+        empty_stream = io.BufferedReader(io.BytesIO())
+        n = self.acd_client.overwrite_stream(empty_stream, n['id'])
+        self.assertEqual(n['contentProperties']['md5'], 'd41d8cd98f00b204e9800998ecf8427e')
+        self.assertEqual(n['contentProperties']['size'], 0)
 
         self.acd_client.move_to_trash(n['id'])
 


### PR DESCRIPTION
I had a look what changes when streaming an empty file compared to uploading an empty file. The body is exactly the same and there's only two differences in the headers: the streamed one containes `Transfer-Encoding: chunked` and lacks `Content-Length`. The sorting is also different, but I can't imagine that that makes a difference.

Providing the content length is obviously not possible and transfer encoding header seems to come from python-requests. I assume requests handles the chunking correctly, since it already handles the multipart body correctly. Also, adding one byte also works fine. So according to my limited understanding of the HTTP standard, acdcli's request is actually correct. 

In any case, the patch here checks if the stream does have at least one byte. If not, it reuses existing methods to create 0-byte files (i.e. ones that specify a Content-Length header). The patch works fine on Linux. The `sys.stdin.buffer` also supports `peek`ing on OSX, but I didn't test the complete patch there. I don't know about Windows. The `try … except` is needed to make test_api_live tests pass, since `mmap` doesn't support peak.

As always, please let me know if you want any changes.