### PR TITLE
fix UnboundLocalError

### DIFF
--- a/acdcli/api/backoff_req.py
+++ b/acdcli/api/backoff_req.py
@@ -4,6 +4,8 @@ import random
 import logging
 from threading import Lock, local
 
+from requests.exceptions import RequestException
+
 from .common import *
 
 logger = logging.getLogger(__name__)
@@ -97,7 +99,8 @@ class BackOffRequest(object):
         try:
             r = self.__session.request(type_, url, auth=self.auth_callback,
                                  headers=headers, timeout=timeout, **kwargs)
-        except:
+        except RequestException as e:
+            r = e.request
             exc = True
             self._failed()
             raise


### PR DESCRIPTION
Name will not be defined after exception raised.

Example traceback:
```
  File "/home/pi/.pyenv/versions/py35/lib/python3.5/site-packages/acdcli/api/content.py", line 281, in download_file
    self.chunked_download(node_id, f, offset=offset, **kwargs)
  File "/home/pi/.pyenv/versions/py35/lib/python3.5/site-packages/acdcli/api/common.py", line 48, in decorated
    return func(*args, **kwargs)
  File "/home/pi/.pyenv/versions/py35/lib/python3.5/site-packages/acdcli/api/content.py", line 318, in chunked_download
    headers={'Range': 'bytes=%d-%d' % (chunk_start, chunk_end)})
  File "/home/pi/.pyenv/versions/py35/lib/python3.5/site-packages/acdcli/api/backoff_req.py", line 117, in get
    return self._request('GET', url, acc_codes, **kwargs)
  File "/home/pi/.pyenv/versions/py35/lib/python3.5/site-packages/acdcli/api/common.py", line 48, in decorated
    return func(*args, **kwargs)
  File "/home/pi/.pyenv/versions/py35/lib/python3.5/site-packages/acdcli/api/backoff_req.py", line 105, in _request
    if (exc or r.status_code not in acc_codes) and 'x-amzn-RequestId' in r.headers:
UnboundLocalError: local variable 'r' referenced before assignment
```