### PR TITLE
support for ecryptfs

### DIFF
--- a/acdcli/cache/schema.py
+++ b/acdcli/cache/schema.py
@@ -28,6 +28,15 @@ _CREATION_SCRIPT = """
         CHECK (status IN ('AVAILABLE', 'TRASH', 'PURGED', 'PENDING'))
     );
 
+    CREATE TABLE properties (
+        id VARCHAR(50) NOT NULL,
+        owner TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT,
+        PRIMARY KEY (id),
+        FOREIGN KEY(id) REFERENCES nodes (id)
+    );
+
     CREATE TABLE labels (
         id VARCHAR(50) NOT NULL,
         name VARCHAR(256) NOT NULL,


### PR DESCRIPTION
Ecryptfs has two properties that we need to overcome in order to get it working with acd_cli.

Luckily, this PR addresses both :-)

1) ecryptfs writes files 4096 bytes at a time, using a different file handle each time. This PR allows multiple file handles to share a write buffer if they all write sequentially. To make this performant for large files (large numbers of file descriptors), I've added some lookup caching to how nodes are obtained.

2) ecryptfs wants to write a cryptographic checksum at the beginning of the file once it's done. We could either buffer everything before sending, which would be memory intensive for big files, or we could have ecryptfs store this checksum in the file's xattr instead. I've opted to go this route, which required implementing xattrs over ACD using one of our allowed properties.

Additionally, ecryptfs is *extremely* chatty about when it decides to write to this buffer. To deal with this, xattrs are marked as dirty and only sent over the wire when any file has all of it's handles closed, or when fuse is unloaded.

With these changes, I can get about 80% of my unencrypted speed to ACD at home using an encrypted mount. If everything in this PR looks good, I have a few ideas of where to push that a bit more.

Please let me know if I grokked the fusepy threading model properly, that's the piece I was the least sure about, especially how safe/unsafe some things were with the GIL.