### PR TITLE
Add an index to the parentage table to improve performance.

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -23,6 +23,8 @@ Thanks to
 
 - `memoz <https://github.com/memoz>`_ for amending proxy documentation
 
+- `gerph <https://github.com/gerph>`_ for making file searches faster, particularly on large repositories
+
 Also thanks to
 
 - `fibersnet <https://github.com/fibersnet>`_ for pointing out a possible deadlock in ACDFuse.


### PR DESCRIPTION
Whilst checking the state of files and directories at the beginning
of an upload, a query is made to find parents. This operation, when
examined with `EXPLAIN QUERY PLAN`, was seen to include a `SCAN TABLE`
over the nodes table. The `COVERING INDEX` on `(parent,child)` was
only used after this step, so was ineffective in speeding up the
operation.

Introducing an explicit index for `parentage(child)` ensures that
the operation is performed much more efficiently, speeding up the
search by at least an order of magnitude (more on larger databases).

The index will only be effective after an `ANALYZE` has been performed
on the database with the new index in place. This, and the addition
of the index, are added as schema version 3, and an appropriate
migration added.

Initial investigation by gerph, hint on where the change is needed
by pep1, and reminder that an `ANALYZE` is required from vb0.

Fixes yadayada/acd_cli#363.
