### PR TITLE
Operations which cause exceptions during a transaction will rollback.

### DIFF
--- a/acdcli/cache/cursors.py
+++ b/acdcli/cache/cursors.py
@@ -21,5 +21,8 @@ class mod_cursor(object):
         return self.cursor
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.conn.commit()
+        if exc_type is None:
+            self.conn.commit()
+        else:
+            self.conn.rollback()
         self.cursor.close()


### PR DESCRIPTION
During the mod_cursor operations, we could leave the operation with a
transaction that was always committed - even in the case where the
operation was incomplete due to an exception occurring. This is quite
counter-intuitive when using transactions - you expect a failure to
rollback any database changes when a problem occurs.

Replacing the commit in the mod_cursor class with a commit-or-rollback
based on whether the exception was raised should at least make the
use of the transactions consistent with what you might expect.