### PR TITLE
Allow commands like du -sk to report the correct file sizes.

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -1082,11 +1082,13 @@ def mount_action(args: argparse.Namespace):
     import acdcli.acd_fuse
     acdcli.acd_fuse.mount(args.path, dict(acd_client=acd_client, cache=cache,
                                           nlinks=args.nlinks, autosync=asp,
+                                          umask=args.umask,
+                                          uid=args.uid,
+                                          gid=args.gid,
                                           settings_path=SETTINGS_PATH),
                           ro=args.read_only, foreground=args.foreground,
                           nothreads=args.single_threaded,
                           nonempty=args.nonempty, modules=args.modules,
-                          umask=args.umask,gid=args.gid,uid=args.uid,
                           allow_root=args.allow_root, allow_other=args.allow_other)
 
 

--- a/acdcli/acd_fuse.py
+++ b/acdcli/acd_fuse.py
@@ -410,9 +410,12 @@ class ACDFuse(LoggingMixIn, Operations):
                         st_nlink=self.cache.num_children(node.id) if self.nlinks else 1,
                         **times)
         elif node.is_file:
+            bs = self.acd_client._conf.getint('transfer','fs_chunk_size')
             return dict(st_mode=stat.S_IFREG | 0o0666,
                         st_nlink=self.cache.num_parents(node.id) if self.nlinks else 1,
                         st_size=size,
+                        st_blksize=bs,
+                        st_blocks=(node.size+511)//512,
                         **times)
 
     def listxattr(self, path):
@@ -528,7 +531,7 @@ class ACDFuse(LoggingMixIn, Operations):
     def statfs(self, path) -> dict:
         """Gets some filesystem statistics as specified in :manpage:`stat(2)`."""
 
-        bs = 512 * 1024  # no effect?
+        bs = self.acd_client._conf.getint('transfer','fs_chunk_size')
         return dict(f_bsize=bs,
                     f_frsize=bs,
                     f_blocks=self.total // bs,  # total no of blocks


### PR DESCRIPTION
Updated the stat(2) returns to include number of blocks and block size.
