### PR TITLE
Moving get_conflicting_node logic into a query for significant speedup

### DIFF
--- a/acdcli/cache/query.py
+++ b/acdcli/cache/query.py
@@ -13,6 +13,12 @@ def datetime_from_string(dt: str) -> datetime:
     return dt
 
 
+CONFLICTING_NODE_SQL = """SELECT n.*, f.* FROM nodes n
+                  JOIN parentage p ON n.id = p.child
+                  LEFT OUTER JOIN files f ON n.id = f.id
+                  WHERE p.parent = (?) AND LOWER(name) = (?) AND status = 'AVAILABLE'
+                  ORDER BY n.name"""
+
 CHILDREN_SQL = """SELECT n.*, f.* FROM nodes n
                   JOIN parentage p ON n.id = p.child
                   LEFT OUTER JOIN files f ON n.id = f.id
@@ -146,10 +152,11 @@ class QueryMixin(object):
 
     def get_conflicting_node(self, name: str, parent_id: str):
         """Finds conflicting node in folder specified by *parent_id*, if one exists."""
-        folders, files = self.list_children(parent_id)
-        for n in folders + files:
-            if n.is_available and n.name.lower() == name.lower():
-                return n
+        with cursor(self._conn) as c:
+            c.execute(CONFLICTING_NODE_SQL, [parent_id, name.lower()])
+            r = c.fetchone()
+            if r:
+                return Node(r)
 
     def resolve(self, path: str, trash=False) -> 'Union[Node|None]':
         segments = list(filter(bool, path.split('/')))


### PR DESCRIPTION
`get_conflicting_node` is called _a lot_, mostly by `upload_file`. The function calls `list_children` to fetch all the nodes under `parent_id`, then that function queries `CHILDREN_SQL` to the cache SQLite database.

It’s mostly harmless, but the problem surfaces when single parent contains _many_ children; e.g., macOS sparsebundle format, used by Time Machine, crams 20000+ 8MB files into one single `bands` folder. That says, every single upload job fetches 20000+ rows from the database, enumerates then objectifies all of them, only to return one case-insensitive-name-conflicting `Node` object or `None`.

Moving the decision logic into the query simplifies the overhead. Intuitively the filtering process might _feel_ the same, but the optimization process differs in many ways. The difference is quite dramatic; well, at least on my fairly outdated Atom N280 @ 1.66GHz 32bit netbook, as shown below.

Before
![before](https://cloud.githubusercontent.com/assets/1336881/19235210/40aef0f0-8f2b-11e6-9d12-f8d76c07ba2c.gif)

After
![after](https://cloud.githubusercontent.com/assets/1336881/19235236/6f2b41c2-8f2b-11e6-968b-aac756b06b44.gif)
