### PR TITLE
Add support for setting --volname or -vn with FUSE

### DIFF
--- a/acd_cli.py
+++ b/acd_cli.py
@@ -1094,7 +1094,8 @@ def mount_action(args: argparse.Namespace):
                           nothreads=args.single_threaded,
                           nonempty=args.nonempty, modules=args.modules,
                           umask=args.umask,gid=args.gid,uid=args.uid,
-                          allow_root=args.allow_root, allow_other=args.allow_other)
+                          allow_root=args.allow_root, allow_other=args.allow_other,
+                          volname=args.volname)
 
 
 @offline_action
@@ -1516,6 +1517,7 @@ def get_parser() -> tuple:
     fuse_sp.add_argument('--nlinks', '-n', action='store_true', help='calculate nlinks')
     fuse_sp.add_argument('--interval', '-i', type=int, default=0,
                          help='sync every x seconds [turned off by default]')
+    fuse_sp.add_argument('--volname', '-vn', help='volume name')
     fuse_sp.add_argument('path')
     fuse_sp.set_defaults(func=mount_action)
 

--- a/acdcli/acd_fuse.py
+++ b/acdcli/acd_fuse.py
@@ -382,10 +382,10 @@ class ACDFuse(LoggingMixIn, Operations):
         autosync = kwargs['autosync']
         conf = kwargs['conf']
 
-        self.rp = ReadProxy(self.acd_client, 
+        self.rp = ReadProxy(self.acd_client,
                             conf.getint('read', 'open_chunk_limit'), conf.getint('read', 'timeout'))
         """collection of files opened for reading"""
-        self.wp = WriteProxy(self.acd_client, self.cache, 
+        self.wp = WriteProxy(self.acd_client, self.cache,
                              conf.getint('write', 'buffer_size'), conf.getint('write', 'timeout'))
         """collection of files opened for writing"""
         try:
@@ -708,6 +708,9 @@ def mount(path: str, args: dict, **kwargs) -> 'Union[int, None]':
     opts = dict(auto_cache=True, sync_read=True)
     if sys.platform == 'linux':
         opts['big_writes']=True
+
+    if kwargs['volname'] is None:
+        del kwargs['volname']
 
     kwargs.update(opts)
 


### PR DESCRIPTION
Currently when mounting in OSX an automatic volume name is assigned:

![image](https://cloud.githubusercontent.com/assets/721323/19999690/eb158978-a2c7-11e6-9247-55d3237a773f.png)

This PR allows for a new option `--volname` or `-vn` which is passed directly through to `FUSE()` as `volname`. This means we can do something like:

```
acd_cli -nl mount ~/Cloud -vn "Amazon Cloud Drive"
```

![image](https://cloud.githubusercontent.com/assets/721323/19999722/168d0220-a2c8-11e6-9e2b-cae160fbd178.png)
